### PR TITLE
fix: Correct product name field reference in sales settlement API

### DIFF
--- a/app/Http/Controllers/SalesSettlementController.php
+++ b/app/Http/Controllers/SalesSettlementController.php
@@ -189,7 +189,7 @@ class SalesSettlementController extends Controller
                 'calculated_total' => $item->calculated_total,
                 'product' => [
                     'id' => $item->product->id,
-                    'name' => $item->product->name,
+                    'name' => $item->product->product_name,
                     'product_code' => $item->product->product_code,
                 ],
                 'uom' => [


### PR DESCRIPTION
Changed product name field from 'name' to 'product_name' to match the actual database column name. This fixes the "Unknown Product" display issue on the sales settlements create page.

The products table uses 'product_name' as the column name, not 'name'.